### PR TITLE
Fixed asktgt kerberos error code 11, and fixed asktgt TGT ticket not working with impacket ticketConverter

### DIFF
--- a/_include/asn_encode.c
+++ b/_include/asn_encode.c
@@ -13,7 +13,7 @@ size_t my_wcslen(const wchar_t* str) {
 DateTime GetLocalTimeAdd(uint add) {
     char datatime[18];
     SYSTEMTIME systemTime;
-    KERNEL32$GetLocalTime(&systemTime);
+    KERNEL32$GetSystemTime(&systemTime);
     FILETIME fileTime;
     KERNEL32$SystemTimeToFileTime(&systemTime, &fileTime);
     ULARGE_INTEGER uli;
@@ -347,7 +347,7 @@ bool AsnEncTimeStampToPaDataEncode(EncryptionKey encKey, PA_DATA* pa_data) {
     pa_data->type = PADATA_ENC_TIMESTAMP;
 
     char datatime[18];
-    DateTime dt = GetGmTimeAdd(0);
+    DateTime dt = GetLocalTimeAdd(0);
     MSVCRT$sprintf(datatime, "%04d%02d%02d%02d%02d%02dZ", dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second);
 
     AsnElt patimestampSeqContext = { 0 };

--- a/asktgt/asktgt.c
+++ b/asktgt/asktgt.c
@@ -250,6 +250,8 @@ BOOL HandleASREP(AsnElt responseAsn, EncryptionKey encKey, byte* serviceKey, BOO
     if (AsnGetEncKDCRepPart(&(ae.sub[0]), &encRepPart)) return TRUE;
 
     KRB_CRED cred = { 0 };
+    cred.pvno = 5;
+    cred.msg_type = 22;
     cred.ticket_count = 1;
     cred.tickets = MemAlloc(sizeof(Ticket) * cred.ticket_count);
     cred.tickets[0] = as_rep.ticket;


### PR DESCRIPTION
First of all thank you, I learned a lot from this project, thank you!

`kerberos error code 11` seems to be due to time issues
https://github.com/RalfHacker/Kerbeus-BOF/issues/3
I changed GetLocalTime to GetSystemTime and it does not report the error again for me.


Another problem is that the generated TGT does not seem to work with impacket ticketConverter.py.
```
bash$ impacket-ticketConverter ./bmb /tmp/ticket
Impacket v0.11.0 - Copyright 2023 Fortra

[*] converting kirbi to ccache...
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyasn1/type/constraint.py", line 32, in __call__
    self._testValue(value, idx)
  File "/usr/lib/python3/dist-packages/pyasn1/type/constraint.py", line 245, in _testValue
    raise error.ValueConstraintError(value)
pyasn1.type.error.ValueConstraintError: 0

During handling of the above exception, another exception occurred:
```



 I used `xxd` to compare the TGT ticket generated by Rubeus and found that there are `0x00` in several places. This seems to be that the KRB_CRED structure does not set pvon and Caused by msg_type