### PR TITLE
IsSystem method modified to check thread token

### DIFF
--- a/asktgs/asktgs.c
+++ b/asktgs/asktgs.c
@@ -90,19 +90,33 @@ BOOL IsSystem(HANDLE TokenHandle) {
     PTOKEN_USER pTokenUser = (PTOKEN_USER)bTokenUser;
     ULONG cbTokenUser;
     SID_IDENTIFIER_AUTHORITY siaNT = SECURITY_NT_AUTHORITY;
-    PSID pSystemSid;
+    PSID pSystemSid = NULL;
+    BOOL bSystem = FALSE;
 
-    if (!ADVAPI32$OpenProcessToken((HANDLE)-1, TOKEN_QUERY, &TokenHandle))
+    // Try to open the token of the current thread first
+    if (!ADVAPI32$OpenThreadToken(KERNEL32$GetCurrentThread(), TOKEN_QUERY, TRUE, &TokenHandle)) {
+        // If there is no thread token, fall back to the process token
+        if (KERNEL32$GetLastError() == ERROR_NO_TOKEN) {
+            if (!ADVAPI32$OpenProcessToken(KERNEL32$GetCurrentProcess(), TOKEN_QUERY, &TokenHandle)) {
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
+
+    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser))
+    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid))
-        return FALSE;
+    bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
 
-    BOOL bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
     ADVAPI32$FreeSid(pSystemSid);
+
     return bSystem;
 }
 

--- a/klist/klist.c
+++ b/klist/klist.c
@@ -31,19 +31,33 @@ BOOL IsSystem(HANDLE TokenHandle) {
     PTOKEN_USER pTokenUser = (PTOKEN_USER)bTokenUser;
     ULONG cbTokenUser;
     SID_IDENTIFIER_AUTHORITY siaNT = SECURITY_NT_AUTHORITY;
-    PSID pSystemSid;
+    PSID pSystemSid = NULL;
+    BOOL bSystem = FALSE;
 
-    if (!ADVAPI32$OpenProcessToken((HANDLE)-1, TOKEN_QUERY, &TokenHandle))
+    // Try to open the token of the current thread first
+    if (!ADVAPI32$OpenThreadToken(KERNEL32$GetCurrentThread(), TOKEN_QUERY, TRUE, &TokenHandle)) {
+        // If there is no thread token, fall back to the process token
+        if (KERNEL32$GetLastError() == ERROR_NO_TOKEN) {
+            if (!ADVAPI32$OpenProcessToken(KERNEL32$GetCurrentProcess(), TOKEN_QUERY, &TokenHandle)) {
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
+
+    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser))
+    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid))
-        return FALSE;
+    bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
 
-    BOOL bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
     ADVAPI32$FreeSid(pSystemSid);
+
     return bSystem;
 }
 

--- a/ptt/ptt.c
+++ b/ptt/ptt.c
@@ -75,19 +75,33 @@ BOOL IsSystem(HANDLE TokenHandle) {
     PTOKEN_USER pTokenUser = (PTOKEN_USER)bTokenUser;
     ULONG cbTokenUser;
     SID_IDENTIFIER_AUTHORITY siaNT = SECURITY_NT_AUTHORITY;
-    PSID pSystemSid;
+    PSID pSystemSid = NULL;
+    BOOL bSystem = FALSE;
 
-    if (!ADVAPI32$OpenProcessToken((HANDLE)-1, TOKEN_QUERY, &TokenHandle))
+    // Try to open the token of the current thread first
+    if (!ADVAPI32$OpenThreadToken(KERNEL32$GetCurrentThread(), TOKEN_QUERY, TRUE, &TokenHandle)) {
+        // If there is no thread token, fall back to the process token
+        if (KERNEL32$GetLastError() == ERROR_NO_TOKEN) {
+            if (!ADVAPI32$OpenProcessToken(KERNEL32$GetCurrentProcess(), TOKEN_QUERY, &TokenHandle)) {
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
+
+    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser))
+    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid))
-        return FALSE;
+    bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
 
-    BOOL bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
     ADVAPI32$FreeSid(pSystemSid);
+
     return bSystem;
 }
 

--- a/purge/purge.c
+++ b/purge/purge.c
@@ -22,19 +22,33 @@ BOOL IsSystem(HANDLE TokenHandle) {
     PTOKEN_USER pTokenUser = (PTOKEN_USER)bTokenUser;
     ULONG cbTokenUser;
     SID_IDENTIFIER_AUTHORITY siaNT = SECURITY_NT_AUTHORITY;
-    PSID pSystemSid;
+    PSID pSystemSid = NULL;
+    BOOL bSystem = FALSE;
 
-    if (!ADVAPI32$OpenProcessToken((HANDLE)-1, TOKEN_QUERY, &TokenHandle))
+    // Try to open the token of the current thread first
+    if (!ADVAPI32$OpenThreadToken(KERNEL32$GetCurrentThread(), TOKEN_QUERY, TRUE, &TokenHandle)) {
+        // If there is no thread token, fall back to the process token
+        if (KERNEL32$GetLastError() == ERROR_NO_TOKEN) {
+            if (!ADVAPI32$OpenProcessToken(KERNEL32$GetCurrentProcess(), TOKEN_QUERY, &TokenHandle)) {
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
+
+    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser))
+    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid))
-        return FALSE;
+    bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
 
-    BOOL bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
     ADVAPI32$FreeSid(pSystemSid);
+
     return bSystem;
 }
 

--- a/s4u/cross_s4u.c
+++ b/s4u/cross_s4u.c
@@ -90,19 +90,33 @@ BOOL IsSystem(HANDLE TokenHandle) {
     PTOKEN_USER pTokenUser = (PTOKEN_USER)bTokenUser;
     ULONG cbTokenUser;
     SID_IDENTIFIER_AUTHORITY siaNT = SECURITY_NT_AUTHORITY;
-    PSID pSystemSid;
+    PSID pSystemSid = NULL;
+    BOOL bSystem = FALSE;
 
-    if (!ADVAPI32$OpenProcessToken((HANDLE)-1, TOKEN_QUERY, &TokenHandle))
+    // Try to open the token of the current thread first
+    if (!ADVAPI32$OpenThreadToken(KERNEL32$GetCurrentThread(), TOKEN_QUERY, TRUE, &TokenHandle)) {
+        // If there is no thread token, fall back to the process token
+        if (KERNEL32$GetLastError() == ERROR_NO_TOKEN) {
+            if (!ADVAPI32$OpenProcessToken(KERNEL32$GetCurrentProcess(), TOKEN_QUERY, &TokenHandle)) {
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
+
+    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser))
+    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid))
-        return FALSE;
+    bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
 
-    BOOL bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
     ADVAPI32$FreeSid(pSystemSid);
+
     return bSystem;
 }
 

--- a/s4u/s4u.c
+++ b/s4u/s4u.c
@@ -89,19 +89,33 @@ BOOL IsSystem(HANDLE TokenHandle) {
     PTOKEN_USER pTokenUser = (PTOKEN_USER)bTokenUser;
     ULONG cbTokenUser;
     SID_IDENTIFIER_AUTHORITY siaNT = SECURITY_NT_AUTHORITY;
-    PSID pSystemSid;
+    PSID pSystemSid = NULL;
+    BOOL bSystem = FALSE;
 
-    if (!ADVAPI32$OpenProcessToken((HANDLE)-1, TOKEN_QUERY, &TokenHandle))
+    // Try to open the token of the current thread first
+    if (!ADVAPI32$OpenThreadToken(KERNEL32$GetCurrentThread(), TOKEN_QUERY, TRUE, &TokenHandle)) {
+        // If there is no thread token, fall back to the process token
+        if (KERNEL32$GetLastError() == ERROR_NO_TOKEN) {
+            if (!ADVAPI32$OpenProcessToken(KERNEL32$GetCurrentProcess(), TOKEN_QUERY, &TokenHandle)) {
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
+
+    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$GetTokenInformation(TokenHandle, TokenUser, pTokenUser, sizeof(bTokenUser), &cbTokenUser))
+    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid)) {
         return FALSE;
+    }
 
-    if (!ADVAPI32$AllocateAndInitializeSid(&siaNT, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &pSystemSid))
-        return FALSE;
+    bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
 
-    BOOL bSystem = ADVAPI32$EqualSid(pTokenUser->User.Sid, pSystemSid);
     ADVAPI32$FreeSid(pSystemSid);
+
     return bSystem;
 }
 


### PR DESCRIPTION
When using token stealing techniques, only the current thread token will be modified, instead of the process token. In that case, previous implementation would treat the process as non-system, but the thread has been actually elevated. 

I added a modification in the IsSystem method to check for the current thread token, returning True if it has System privileges. If the thread token is not available, it falls back to checking the process token as it was done before.